### PR TITLE
Cleanup Confluence overview dashboard

### DIFF
--- a/Overview.json
+++ b/Overview.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -21,11 +24,15 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 26,
+  "id": 301,
   "links": [],
   "liveNow": false,
   "panels": [
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -97,7 +104,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.2",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -115,6 +122,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -172,7 +183,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.2",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -190,6 +201,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -247,7 +262,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.2",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -265,6 +280,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -322,7 +341,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.2",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -340,8 +359,12 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
-        "h": 11,
+        "h": 4,
         "w": 3,
         "x": 12,
         "y": 0
@@ -362,7 +385,6 @@
           "error": true,
           "execution_error": false,
           "firing": true,
-          "inactive": false,
           "noData": false,
           "no_data": false,
           "normal": false,
@@ -370,11 +392,16 @@
           "paused": false,
           "pending": false
         },
-        "tags": []
+        "tags": [],
+        "viewMode": "list"
       },
       "pluginVersion": "8.2.5",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "exemplar": true,
           "expr": "java_lang_OperatingSystem_AvailableProcessors{}",
           "interval": "",
@@ -386,12 +413,18 @@
       "type": "alertlist"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -437,12 +470,12 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 9,
         "x": 15,
         "y": 0
@@ -452,7 +485,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -488,6 +522,83 @@
       ],
       "title": "GC Time",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "index": 0,
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 4
+      },
+      "id": 18,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "jvm_threads_state{state=\"BLOCKED\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{ state }} ({{instance}})",
+          "refId": "D"
+        }
+      ],
+      "title": "Blocked Threads",
+      "type": "gauge"
     },
     {
       "alert": {
@@ -530,6 +641,10 @@
           }
         ]
       },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -537,6 +652,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -597,7 +714,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -669,12 +787,18 @@
           }
         ]
       },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -735,7 +859,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -767,198 +892,10 @@
       "type": "timeseries"
     },
     {
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 60
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 9,
-        "x": 15,
-        "y": 10
-      },
-      "id": 34,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "exemplar": true,
-          "expr": "increase(java_lang_G1_Old_Generation_CollectionCount{product=\"confluence\"}[10m])",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "legendFormat": "G1_Old_Generation ({{instance}})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "exemplar": true,
-          "expr": "increase(java_lang_G1_Young_Generation_CollectionCount{product=\"confluence\"}[10m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "G1_Young_Generation ({{instance}})",
-          "refId": "B"
-        }
-      ],
-      "title": "GC Count",
-      "type": "timeseries"
-    },
-    {
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "index": 0,
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 3,
-        "x": 12,
-        "y": 11
-      },
-      "id": 18,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "text": {}
-      },
-      "pluginVersion": "8.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "exemplar": true,
-          "expr": "jvm_threads_state{state=\"BLOCKED\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{ state }} ({{instance}})",
-          "refId": "D"
-        }
-      ],
-      "title": "Blocked Threads",
-      "type": "gauge"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 19
-      },
-      "id": 32,
-      "panels": [],
-      "title": "Tomcat",
-      "type": "row"
-    },
-    {
       "datasource": {
         "type": "prometheus",
-        "uid": "$datasource"
+        "uid": "prometheus"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1013,12 +950,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
-        "w": 16,
-        "x": 0,
-        "y": 32
+        "h": 11,
+        "w": 6,
+        "x": 12,
+        "y": 8
       },
-      "id": 38,
+      "id": 40,
       "options": {
         "legend": {
           "calcs": [],
@@ -1035,25 +972,165 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "com_atlassian_confluence_metrics_Mean{category00=\"db\",category01=\"connection\",category02=\"latency\",name=\"statistics\"}",
-          "legendFormat": "{{instance}}",
+          "expr": "com_atlassian_confluence_metrics_Mean{category00=\"jvm\", category01=\"gc\", product=\"confluence\"}",
+          "legendFormat": "{{instance}} - {{tag_cause}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Database Latency",
+      "title": "GC Pauses",
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 60
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "increase(java_lang_G1_Old_Generation_CollectionCount{product=\"confluence\"}[10m])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "G1_Old_Generation ({{instance}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "increase(java_lang_G1_Young_Generation_CollectionCount{product=\"confluence\"}[10m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "G1_Young_Generation ({{instance}})",
+          "refId": "B"
+        }
+      ],
+      "title": "GC Count",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 32,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Tomcat",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1110,7 +1187,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1187,12 +1265,18 @@
           }
         ]
       },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1253,7 +1337,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1286,12 +1371,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1348,7 +1439,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1373,12 +1465,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1442,7 +1540,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1481,6 +1580,10 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1489,8 +1592,212 @@
       },
       "id": 30,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Database",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 16,
+        "x": 0,
+        "y": 32
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "com_atlassian_confluence_metrics_Mean{category00=\"db\",category01=\"connection\",category02=\"latency\",name=\"statistics\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "rate(com_atlassian_confluence_metrics_Count{category00=\"postgres\",name=\"reads\"}[10m])",
+          "interval": "",
+          "legendFormat": "reads ({{instance}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "rate(com_atlassian_confluence_metrics_Count{category00=\"postgres\",name=\"writes\"}[10m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "writes ({{instance}})",
+          "refId": "B"
+        }
+      ],
+      "title": "Reads / Writes",
+      "type": "timeseries"
     },
     {
       "alert": {
@@ -1533,6 +1840,10 @@
           }
         ]
       },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1571,8 +1882,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1588,14 +1898,15 @@
         "h": 14,
         "w": 8,
         "x": 0,
-        "y": 32
+        "y": 46
       },
       "id": 10,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1627,6 +1938,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1665,8 +1980,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1682,14 +1996,15 @@
         "h": 14,
         "w": 8,
         "x": 8,
-        "y": 32
+        "y": 46
       },
       "id": 35,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1723,108 +2038,11 @@
       ],
       "title": "Connection Pool",
       "type": "timeseries"
-    },
-    {
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 14,
-        "w": 8,
-        "x": 16,
-        "y": 32
-      },
-      "id": 36,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "exemplar": true,
-          "expr": "rate(com_atlassian_confluence_metrics_Count{category00=\"postgres\",name=\"reads\"}[10m])",
-          "interval": "",
-          "legendFormat": "reads ({{instance}})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "exemplar": true,
-          "expr": "rate(com_atlassian_confluence_metrics_Count{category00=\"postgres\",name=\"writes\"}[10m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "writes ({{instance}})",
-          "refId": "B"
-        }
-      ],
-      "title": "Reads / Writes",
-      "type": "timeseries"
     }
   ],
   "refresh": "",
-  "schemaVersion": 35,
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "confluence"
@@ -1833,7 +2051,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "default",
           "value": "default"
         },
@@ -1858,7 +2076,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Confluence Overview",
+  "title": "Confluence Overview 1",
   "version": 1,
   "weekStart": ""
 }

--- a/Overview.json
+++ b/Overview.json
@@ -102,7 +102,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "java_lang_Runtime_Pid{product=\"confluence\"}",
@@ -177,7 +177,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "java_lang_Runtime_Uptime{product=\"confluence\"}/1000",
@@ -252,7 +252,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "java_lang_Runtime_StartTime{product=\"confluence\"}",
@@ -327,7 +327,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "java_lang_OperatingSystem_AvailableProcessors{product=\"confluence\"}",
@@ -336,7 +336,7 @@
           "refId": "A"
         }
       ],
-      "title": "CPU Cores",
+      "title": "Available CPU Cores",
       "type": "stat"
     },
     {
@@ -376,7 +376,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "java_lang_OperatingSystem_AvailableProcessors{instance=\"localhost:9000\"}",
+          "expr": "java_lang_OperatingSystem_AvailableProcessors{}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -463,26 +463,26 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "increase(java_lang_G1_Old_Generation_CollectionTime{product=\"confluence\"}[10m])",
           "format": "time_series",
           "hide": false,
           "interval": "60s",
-          "legendFormat": "{{gc}} ({{instance}})",
+          "legendFormat": "G1_Old_Generation ({{instance}})",
           "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "increase(java_lang_G1_Young_Generation_CollectionTime{product=\"confluence\"}[10m])",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "G1_Young_Generation ({{instance}})",
           "refId": "B"
         }
       ],
@@ -608,7 +608,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "(java_lang_OperatingSystem_ProcessCpuLoad{product=\"confluence\"} * 100)",
@@ -746,7 +746,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "100*(jvm_memory_bytes_used{area=\"heap\",product=\"confluence\"}/jvm_memory_bytes_max{area=\"heap\",product=\"confluence\"})",
@@ -815,7 +815,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -841,26 +841,26 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "increase(java_lang_G1_Old_Generation_CollectionCount{product=\"confluence\"}[10m])",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
-          "legendFormat": "{{gc}} ({{instance}})",
+          "legendFormat": "G1_Old_Generation ({{instance}})",
           "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "increase(java_lang_G1_Young_Generation_CollectionCount{product=\"confluence\"}[10m])",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "G1_Young_Generation ({{instance}})",
           "refId": "B"
         }
       ],
@@ -927,7 +927,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "jvm_threads_state{state=\"BLOCKED\"}",
@@ -952,6 +952,100 @@
       "panels": [],
       "title": "Tomcat",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 16,
+        "x": 0,
+        "y": 32
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "com_atlassian_confluence_metrics_Mean{category00=\"db\",category01=\"connection\",category02=\"latency\",name=\"statistics\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database Latency",
+      "type": "timeseries"
     },
     {
       "fieldConfig": {
@@ -1027,10 +1121,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "increase(Standalone_GlobalRequestProcessor_requestCount[10m])",
+          "expr": "increase(Standalone_GlobalRequestProcessor_requestCount{}[10m])",
           "hide": false,
           "interval": "",
           "legendFormat": "{{name}} count ({{instance}})",
@@ -1039,10 +1133,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "increase(Standalone_GlobalRequestProcessor_errorCount[10m])",
+          "expr": "increase(Standalone_GlobalRequestProcessor_errorCount{}[10m])",
           "hide": false,
           "interval": "",
           "legendFormat": "{{name}} error ({{instance}})",
@@ -1170,10 +1264,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "(Standalone_ThreadPool_currentThreadCount / Standalone_ThreadPool_maxThreads) * 100",
+          "expr": "(Standalone_ThreadPool_currentThreadCount{} / Standalone_ThreadPool_maxThreads{}) * 100",
           "hide": false,
           "interval": "",
           "legendFormat": "used {{name}} ({{instance}})",
@@ -1265,10 +1359,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "increase(Standalone_GlobalRequestProcessor_processingTime[10m]) / increase(Standalone_GlobalRequestProcessor_requestCount[10m])",
+          "expr": "increase(Standalone_GlobalRequestProcessor_processingTime{}[10m]) / increase(Standalone_GlobalRequestProcessor_requestCount{}[10m])",
           "hide": false,
           "interval": "",
           "legendFormat": "{{name}} ({{instance}})",
@@ -1360,10 +1454,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "Standalone_Manager_activeSessions",
+          "expr": "Standalone_Manager_activeSessions{}",
           "hide": false,
           "interval": "",
           "legendFormat": "active sessions: {{context}} ({{instance}})",
@@ -1372,10 +1466,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "Standalone_Manager_rejectedSessions",
+          "expr": "Standalone_Manager_rejectedSessions{}",
           "hide": false,
           "interval": "",
           "legendFormat": "rejected sessions: {{context}} ({{instance}})",
@@ -1512,10 +1606,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "(com_mchange_v2_c3p0_PooledDataSource_numBusyConnections / com_mchange_v2_c3p0_PooledDataSource_maxPoolSize) * 100",
+          "expr": "(com_mchange_v2_c3p0_PooledDataSource_numBusyConnections{} / com_mchange_v2_c3p0_PooledDataSource_maxPoolSize{}) * 100",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -1606,10 +1700,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "com_mchange_v2_c3p0_PooledDataSource_numBusyConnections",
+          "expr": "com_mchange_v2_c3p0_PooledDataSource_numBusyConnections{}",
           "interval": "",
           "legendFormat": "active {{instance}}",
           "refId": "A"
@@ -1617,10 +1712,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "com_mchange_v2_c3p0_PooledDataSource_numIdleConnections",
+          "expr": "com_mchange_v2_c3p0_PooledDataSource_numIdleConnections{}",
           "hide": false,
           "interval": "",
           "legendFormat": "idle {{instance}}",
@@ -1704,7 +1799,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "rate(com_atlassian_confluence_metrics_Count{category00=\"postgres\",name=\"reads\"}[10m])",
@@ -1715,7 +1810,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "rate(com_atlassian_confluence_metrics_Count{category00=\"postgres\",name=\"writes\"}[10m])",
@@ -1732,18 +1827,39 @@
   "refresh": "",
   "schemaVersion": 35,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "confluence"
+  ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Overview",
-  "uid": "IeEDnNp7x",
-  "version": 22,
+  "title": "Confluence Overview",
+  "version": 1,
   "weekStart": ""
 }

--- a/Overview.json
+++ b/Overview.json
@@ -956,7 +956,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {

--- a/Overview.json
+++ b/Overview.json
@@ -2076,7 +2076,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Confluence Overview 1",
+  "title": "Confluence Overview",
   "version": 1,
   "weekStart": ""
 }

--- a/Overview.json
+++ b/Overview.json
@@ -1700,7 +1700,6 @@
         {
           "datasource": {
             "type": "prometheus",
-
             "uid": "$datasource"
           },
           "exemplar": true,


### PR DESCRIPTION
This PR fixes a few issues with the Overview dashboard:

* remove hardcoded prometheus datasource UIDs and instead introduce datasource variables in `templating.list`:

<img width="278" alt="image" src="https://github.com/atlassian-labs/Confluence-DC-Grafana-Dashboards/assets/52448429/6b02e85a-0380-4712-ab4a-1279f6eca821">

* remove any localhost references in metrics
* use a common default `from now-6h` time period
* append `{}` to metrics that don't have it (we'll be using it in find replace script that converts the dashboard to k8s friendly format)
* fix unit for gc time - ms instead of s
* fix unit for gc count - number instead of seconds
* add db latency panel to database section (recommended by support enginers)
* fix legend for gc metrics, there's no {{gc}} attribute in the returned metric value
* remove uid for the dashboard itself - let Grafana create it when the dashboard is being imported
* Add Confluence to the dashboard name :) 