### PR TITLE
Add inputs to Grafana dashoards

### DIFF
--- a/bitbucket/build-actions-thread-pool-stats.json
+++ b/bitbucket/build-actions-thread-pool-stats.json
@@ -1,11 +1,21 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
         "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
         },
         "enable": true,
         "hide": true,
@@ -32,7 +42,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The current number of threads in the pool",
       "fieldConfig": {
@@ -112,7 +122,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_BuildActionsThreadPool_PoolSize{}[5m])",
@@ -127,7 +137,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate number of threads that are actively executing tasks",
       "fieldConfig": {
@@ -207,7 +217,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_BuildActionsThreadPool_ActiveCount{}[5m])",
@@ -222,7 +232,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The number of tasks awaiting execution by the thread pool",
       "fieldConfig": {
@@ -302,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_BuildActionsThreadPool_QueueLength{}[5m])",
@@ -317,7 +327,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate total number of tasks that have completed execution. Because the states of tasks and threads may change dynamically during computation, the returned value is only an approximation, but one that does not ever decrease across successive calls",
       "fieldConfig": {
@@ -397,7 +407,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_BuildActionsThreadPool_CompletedTaskCount{}[5m])",
@@ -412,7 +422,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The largest number of threads that have ever been simultaneously in the pool",
       "fieldConfig": {
@@ -492,7 +502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_BuildActionsThreadPool_LargestPoolSize{}[5m])",
@@ -507,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The maximum allowed number of threads",
       "fieldConfig": {
@@ -587,7 +597,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_BuildActionsThreadPool_MaximumPoolSize{}[5m])",

--- a/bitbucket/db-ops.json
+++ b/bitbucket/db-ops.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -31,7 +41,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Active Connections (in use)",
       "fieldConfig": {
@@ -111,7 +121,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_zaxxer_hikari_Pool_bitbucket_ActiveConnections{}[5m])",
@@ -126,7 +136,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Idle Connection count",
       "fieldConfig": {
@@ -206,7 +216,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_zaxxer_hikari_Pool_bitbucket_IdleConnections{}[5m])",
@@ -221,7 +231,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The number of threads waiting for a connection (when all available connections are in use)",
       "fieldConfig": {
@@ -301,7 +311,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_zaxxer_hikari_Pool_bitbucket_ThreadsAwaitingConnection{}[5m])",
@@ -316,7 +326,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total Connections",
       "fieldConfig": {
@@ -396,7 +406,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_zaxxer_hikari_Pool_bitbucket_TotalConnections{}[5m])",
@@ -411,7 +421,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Global number of cached queries successfully retrieved from cache",
       "fieldConfig": {
@@ -491,7 +501,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(org_hibernate_core_bitbucket_core_QueryCacheHitCount{}[5m])",
@@ -506,7 +516,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Global number of cacheable entities/collections successfully retrieved from the cache",
       "fieldConfig": {
@@ -586,7 +596,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(org_hibernate_core_bitbucket_core_SecondLevelCacheHitCount{}[5m])",
@@ -602,7 +612,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Global number of cached queries not found in cache",
       "fieldConfig": {
@@ -682,7 +692,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(org_hibernate_core_bitbucket_core_QueryCacheMissCount{}[5m])",
@@ -697,7 +707,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Global number of cacheable entities/collections not found in the cache and loaded from the database",
       "fieldConfig": {
@@ -777,7 +787,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(org_hibernate_core_bitbucket_core_SecondLevelCacheMissCount{}[5m])",

--- a/bitbucket/event-thread-pool-stats.json
+++ b/bitbucket/event-thread-pool-stats.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -32,7 +42,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The current number of threads in the pool",
       "fieldConfig": {
@@ -112,7 +122,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_EventThreadPool_PoolSize{}[5m])",
@@ -127,7 +137,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate number of threads that are actively executing tasks",
       "fieldConfig": {
@@ -207,7 +217,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_EventThreadPool_ActiveCount{}[5m])",
@@ -222,7 +232,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The number of tasks awaiting execution by the thread pool",
       "fieldConfig": {
@@ -302,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_EventThreadPool_QueueLength{}[5m])",
@@ -317,7 +327,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate total number of tasks that have completed execution. Because the states of tasks and threads may change dynamically during computation, the returned value is only an approximation, but one that does not ever decrease across successive calls",
       "fieldConfig": {
@@ -397,7 +407,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_EventThreadPool_CompletedTaskCount{}[5m])",
@@ -412,7 +422,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The largest number of threads that have ever been simultaneously in the pool",
       "fieldConfig": {
@@ -492,7 +502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_EventThreadPool_LargestPoolSize{}[5m])",
@@ -507,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The maximum allowed number of threads",
       "fieldConfig": {
@@ -587,7 +597,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_EventThreadPool_MaximumPoolSize{}[5m])",

--- a/bitbucket/git-ops.json
+++ b/bitbucket/git-ops.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/bitbucket/io-pump-thread-pool-stats.json
+++ b/bitbucket/io-pump-thread-pool-stats.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -32,7 +42,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The current number of threads in the pool",
       "fieldConfig": {
@@ -112,7 +122,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_IoPumpThreadPool_PoolSize{}[5m])",
@@ -127,7 +137,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate number of threads that are actively executing tasks",
       "fieldConfig": {
@@ -207,7 +217,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_IoPumpThreadPool_ActiveCount{}[5m])",
@@ -222,7 +232,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The number of tasks awaiting execution by the thread pool",
       "fieldConfig": {
@@ -302,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_IoPumpThreadPool_QueueLength{}[5m])",
@@ -317,7 +327,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate total number of tasks that have completed execution. Because the states of tasks and threads may change dynamically during computation, the returned value is only an approximation, but one that does not ever decrease across successive calls",
       "fieldConfig": {
@@ -397,7 +407,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_IoPumpThreadPool_CompletedTaskCount{}[5m])",
@@ -412,7 +422,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The largest number of threads that have ever been simultaneously in the pool",
       "fieldConfig": {
@@ -492,7 +502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_IoPumpThreadPool_LargestPoolSize{}[5m])",
@@ -507,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The maximum allowed number of threads",
       "fieldConfig": {
@@ -587,7 +597,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_IoPumpThreadPool_MaximumPoolSize{}[5m])",

--- a/bitbucket/nio-pump-thread-pool-stats.json
+++ b/bitbucket/nio-pump-thread-pool-stats.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -32,7 +42,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The current number of threads in the pool",
       "fieldConfig": {
@@ -112,7 +122,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_NioPumpThreadPool_PoolSize{}[5m])",
@@ -127,7 +137,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate number of threads that are actively executing tasks",
       "fieldConfig": {
@@ -207,7 +217,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_NioPumpThreadPool_ActiveCount{}[5m])",
@@ -222,7 +232,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The number of tasks awaiting execution by the thread pool",
       "fieldConfig": {
@@ -302,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_NioPumpThreadPool_QueueLength{}[5m])",
@@ -317,7 +327,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate total number of tasks that have completed execution. Because the states of tasks and threads may change dynamically during computation, the returned value is only an approximation, but one that does not ever decrease across successive calls",
       "fieldConfig": {
@@ -397,7 +407,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_NioPumpThreadPool_CompletedTaskCount{}[5m])",
@@ -412,7 +422,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The largest number of threads that have ever been simultaneously in the pool",
       "fieldConfig": {
@@ -492,7 +502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_NioPumpThreadPool_LargestPoolSize{}[5m])",
@@ -507,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The maximum allowed number of threads",
       "fieldConfig": {
@@ -587,7 +597,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_NioPumpThreadPool_MaximumPoolSize{}[5m])",

--- a/bitbucket/overview.json
+++ b/bitbucket/overview.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/bitbucket/scheduled-thread-pool-stats.json
+++ b/bitbucket/scheduled-thread-pool-stats.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -32,7 +42,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The current number of threads in the pool",
       "fieldConfig": {
@@ -112,7 +122,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_ScheduledThreadPool_PoolSize{}[5m])",
@@ -127,7 +137,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate number of threads that are actively executing tasks",
       "fieldConfig": {
@@ -207,7 +217,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_ScheduledThreadPool_ActiveCount{}[5m])",
@@ -222,7 +232,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The number of tasks awaiting execution by the thread pool",
       "fieldConfig": {
@@ -302,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_ScheduledThreadPool_QueueLength{}[5m])",
@@ -317,7 +327,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The approximate total number of tasks that have completed execution. Because the states of tasks and threads may change dynamically during computation, the returned value is only an approximation, but one that does not ever decrease across successive calls",
       "fieldConfig": {
@@ -397,7 +407,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_ScheduledThreadPool_CompletedTaskCount{}[5m])",
@@ -412,7 +422,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The largest number of threads that have ever been simultaneously in the pool",
       "fieldConfig": {
@@ -492,7 +502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_ScheduledThreadPool_LargestPoolSize{}[5m])",
@@ -507,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The maximum allowed number of threads",
       "fieldConfig": {
@@ -588,7 +598,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_thread_pools_ScheduledThreadPool_MaximumPoolSize{}[5m])",

--- a/bitbucket/ssh-session-stats.json
+++ b/bitbucket/ssh-session-stats.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -32,7 +42,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of currently active SSH session",
       "fieldConfig": {
@@ -112,7 +122,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_SshSessions_ActiveSessionCount{}[5m])",
@@ -127,7 +137,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Highest number of concurrently active SSH sessions since the last startup",
       "fieldConfig": {
@@ -207,7 +217,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_SshSessions_MaxActiveSessionCount{}[5m])",
@@ -222,7 +232,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of SSH sessions that have been created since the last startup",
       "fieldConfig": {
@@ -302,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_SshSessions_SessionCreatedCount{}[5m])",
@@ -317,7 +327,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of SSH sessions that have been closed since the last startup\n",
       "fieldConfig": {
@@ -397,7 +407,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_SshSessions_SessionClosedCount{}[5m])",
@@ -413,7 +423,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of SSH sessions that have been terminated because an exception was thrown from the SSH command run\n",
       "fieldConfig": {
@@ -493,7 +503,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_bitbucket_SshSessions_SessionExceptionCount{}[5m])",

--- a/bitbucket/ticket-status.json
+++ b/bitbucket/ticket-status.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/bitbucket/webhooks-stats.json
+++ b/bitbucket/webhooks-stats.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -32,7 +42,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "A count of the total number of events that could trigger webhooks\n(A publish may create many dispatches)",
       "fieldConfig": {
@@ -112,7 +122,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_webhooks_Webhooks_PublishCount{}[5m])",
@@ -127,7 +137,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of webhooks to fire successfully with a successful HTTP response(A publish may create many dispatches)",
       "fieldConfig": {
@@ -207,7 +217,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_webhooks_Webhooks_DispatchSuccessCount{}[5m])",
@@ -222,7 +232,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "A count of the number of webhook dispatches that were rejected for execution",
       "fieldConfig": {
@@ -302,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_webhooks_Webhooks_DispatchRejectedCount{}[5m])",
@@ -317,7 +327,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The last time a webhook was rejected, either from circuit breaking, or due to too many webhooks being in flight",
       "fieldConfig": {
@@ -397,7 +407,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_webhooks_Webhooks_DispatchLastRejectedTimestamp{}[5m])",
@@ -412,7 +422,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of dispatches that have been triggered and are awaiting resolution",
       "fieldConfig": {
@@ -492,7 +502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_webhooks_Webhooks_DispatchInFlightCount{}[5m])",
@@ -507,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of webhooks that fired successfully, but the HTTP response indicates a failure\n(non 2xx code)",
       "fieldConfig": {
@@ -587,7 +597,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_webhooks_Webhooks_DispatchFailureCount{}[5m])",
@@ -602,7 +612,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of webhooks to have had an error while they were being dispatched(non 2xx code)",
       "fieldConfig": {
@@ -682,7 +692,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_webhooks_Webhooks_DispatchErrorCount{}[5m])",
@@ -697,7 +707,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of webhooks to have been dispatched",
       "fieldConfig": {
@@ -777,7 +787,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "increase(com_atlassian_webhooks_Webhooks_DispatchCount{}[5m])",


### PR DESCRIPTION
- Added input section to the dashboards so that it promps what datasource to use when importing them. Before this change it used the default one. 
- Also updated the panel datasources to use $DS_PROMETHEUS (The selected datasource when importing)